### PR TITLE
Add take and join for sparse_mat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,14 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Windows Executable files
+*.exe
+*.dll
+
+# Windows Batch files
+*.bat
+*.cmd
+
+# VS Code settings
+.vscode/

--- a/sparse_mat.h
+++ b/sparse_mat.h
@@ -72,6 +72,36 @@ namespace SparseRREF {
 		sparse_mat_transpose_part_replace(tranmat, mat, rows, pool);
 	}
 
+	// join two sparse matrices
+	template <typename T, typename index_t>
+	sparse_mat<T, index_t> sparse_mat_join(const sparse_mat<T, index_t>& A, const sparse_mat<T, index_t>& B, thread_pool* pool = nullptr) {
+		if (A.ncol != B.ncol)
+			throw std::invalid_argument("sparse_mat_join: column number mismatch");
+
+		sparse_mat<T, index_t> res(A.nrow + B.nrow, A.ncol);
+
+		if (pool == nullptr) {
+			for (size_t i = 0; i < A.nrow; i++) {
+				res[i] = A[i];
+			}
+			for (size_t i = 0; i < B.nrow; i++) {
+				res[i + A.nrow] = B[i];
+			}
+		}
+		else {
+			pool->detach_loop(0, A.nrow, [&](size_t i) {
+				res[i] = A[i];
+			});
+			pool->wait();
+			pool->detach_loop(0, B.nrow, [&](size_t i) {
+				res[i + A.nrow] = B[i];
+			});
+			pool->wait();
+		}
+
+		return res;
+	}
+
 	// rref staffs
 
 	// first look for rows with only one nonzero value and eliminate them

--- a/sparse_type.h
+++ b/sparse_type.h
@@ -520,6 +520,32 @@ namespace SparseRREF {
 			return res;
 		}
 
+		// take a span of rows
+		// sparse_mat.take({start, end}) returns a sparse_mat with rows indexed in [start, end)
+		sparse_mat<T, index_t> take(const std::pair<size_t, size_t>& span, thread_pool* pool = nullptr) const {
+			sparse_mat<T, index_t> res(span.second - span.first, ncol);
+			
+			if (pool == nullptr) {
+				for (size_t i = span.first; i < span.second; i++) {
+					res[i - span.first] = rows[i];
+				}
+			}
+			else {
+				pool->detach_loop(span.first, span.second, [&](size_t i) {
+					res[i - span.first] = rows[i];
+				});
+				pool->wait();
+			}
+			return res;
+		}
+
+		// sort rows by nnz
+		void sort_rows_by_nnz() {
+			std::stable_sort(rows.begin(), rows.end(), [](const sparse_vec<T, index_t>& a, const sparse_vec<T, index_t>& b) {
+				return a.nnz() < b.nnz();
+			});
+		}
+
 		template <typename U = T> requires std::is_same_v<U, rat_t>
 		sparse_mat<ulong> operator%(const nmod_t mod) const {
 			sparse_mat<ulong> result(nrow, ncol);

--- a/wxf_support.h
+++ b/wxf_support.h
@@ -554,7 +554,10 @@ namespace WXF_PARSER {
 		ExprNode() : index(0), size(0), children(nullptr), type(i8) {} // default constructor
 
 		ExprNode(size_t idx, size_t sz, WXF_HEAD t) : index(idx), size(sz), type(t) {
-			if (size > 0) {
+			constexpr size_t MAX_ALLOC = std::numeric_limits<ssize_t>::max();
+			if (size > MAX_ALLOC) {
+    			throw std::bad_alloc();
+			} else if (size > 0) {
 				children = std::make_unique<ExprNode[]>(size);
 			}
 		}


### PR DESCRIPTION
### CHANGES:
- add ``sparse_mat.take({start, end})`` which returns a ``sparse_mat`` with rows indexed in ``[start, end)``
- add ``sparse_mat_join(A, B)`` which is equivalent to ``Join[A, B]`` in Mathematica
### TODO:
- [ ] ``sparse_mat_join`` with ``move``
- [ ] ``sparse_mat_join`` as member function of ``sparse_mat`` (maybe renamed as ``append``?)
- [ ] ``take`` and ``join`` for ``sparse_tensor``