### PR TITLE
shrink memory in rref

### DIFF
--- a/sparse_mat.h
+++ b/sparse_mat.h
@@ -152,6 +152,7 @@ namespace SparseRREF {
 			std::make_move_iterator(mat.rows.end()));
 
 		mat.rows.clear();
+		mat.rows.shrink_to_fit();
 		mat.nrow = 0;
 		mat.ncol = 0;
 
@@ -1987,8 +1988,9 @@ namespace SparseRREF {
 				for (auto [r, c] : p)
 					rowset[r] = c;
 			for (size_t i = 0; i < mat.nrow; i++)
-				if (rowset[i] == -1)
-					mat[i].zero();
+				if (rowset[i] == -1) {
+					mat[i].clear();
+				}
 		}
 
 		while (!isok || mod.bits() < mat_height_bits) {

--- a/sparse_type.h
+++ b/sparse_type.h
@@ -344,6 +344,11 @@ namespace SparseRREF {
 			if (n == _alloc)
 				return;
 
+			if (n == 0) {
+				clear();
+				return;
+			}
+
 			if (_alloc == 0) {
 				indices = s_malloc<index_t>(n);
 				_alloc = n;
@@ -693,8 +698,12 @@ namespace SparseRREF {
 		}
 
 		void reserve(size_t size) {
-			if (size == 0 || size == alloc)
+			if (size == alloc)
 				return;
+			if (size == 0) {
+				clear();
+				return;
+			}
 			if (alloc == 0) {
 				alloc = size;
 				colptr = s_malloc<index_t>(size * (rank - 1));


### PR DESCRIPTION
### CHANGES
- use ``clear()`` in ``reserve(0)`` for ``sparse_vec<bool, index_t>`` and ``sparse_tensor_struct``
- clear zero rows in ``sparse_mat_rref_reconstruct``